### PR TITLE
feat: add badge management and service update functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,11 @@
 			<artifactId>jjwt-jackson</artifactId>
 			<version>0.11.5</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/service_health_monitor_portal/log_analyzer/controllers/BadgeController.java
+++ b/src/main/java/com/service_health_monitor_portal/log_analyzer/controllers/BadgeController.java
@@ -1,9 +1,7 @@
 package com.service_health_monitor_portal.log_analyzer.controllers;
 
 import java.util.List;
-import java.util.Set;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,53 +11,40 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.service_health_monitor_portal.log_analyzer.dto.BadgeIdsDTO;
+import com.service_health_monitor_portal.log_analyzer.dto.BadgeDTO;
 import com.service_health_monitor_portal.log_analyzer.entity.BadgeEntity;
-import com.service_health_monitor_portal.log_analyzer.services.ServiceService;
+import com.service_health_monitor_portal.log_analyzer.services.BadgeService;
 
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/services")
+@RequestMapping("/api/badges")
 @RequiredArgsConstructor
 public class BadgeController {
-    private final ServiceService serviceService;
+    private final BadgeService badgeService;
 
-    // Get all badges for a specific service
-    @GetMapping("/{serviceId}/badges")
-    public ResponseEntity<?> getBadges(@PathVariable Long serviceId) {
-        try {
-            Set<BadgeEntity> badges = serviceService.getBadgesForService(serviceId);
-            return ResponseEntity.ok(badges);
-        } catch (RuntimeException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body("Error fetching badges for service ID " + serviceId + ": " + e.getMessage());
-        }
+    @GetMapping
+    public ResponseEntity<List<BadgeEntity>> getAllBadges() {
+        return ResponseEntity.ok(badgeService.getAllBadges());
     }
 
-    // Add badges to a service
-    @PostMapping("/{serviceId}/badges")
-    public ResponseEntity<String> addBadges(@PathVariable Long serviceId, @RequestBody BadgeIdsDTO badgeIdsDTO) {
-        List<Long> badgeIds = badgeIdsDTO.getBadgeIds();
-        try {
-            serviceService.addBadgesToService(serviceId, badgeIds);
-            return ResponseEntity.ok("Badges added successfully");
-        } catch (RuntimeException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body("Error adding badges to service ID " + serviceId + ": " + e.getMessage());
+    @GetMapping("/{id}")
+    public ResponseEntity<BadgeEntity> getBadge(@PathVariable Long id) {
+        BadgeEntity badge = badgeService.getBadgeById(id);
+        if (badge == null) {
+            return ResponseEntity.notFound().build();
         }
+        return ResponseEntity.ok(badge);
     }
 
-    // Remove badges from a service
-    @DeleteMapping("/{serviceId}/badges")
-    public ResponseEntity<String> removeBadges(@PathVariable Long serviceId, @RequestBody BadgeIdsDTO badgeIdsDTO) {
-        List<Long> badgeIds = badgeIdsDTO.getBadgeIds();
-        try {
-            serviceService.removeBadgesFromService(serviceId, badgeIds);
-            return ResponseEntity.ok("Badges removed successfully");
-        } catch (RuntimeException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body("Error removing badges from service ID " + serviceId + ": " + e.getMessage());
-        }
+    @PostMapping
+    public ResponseEntity<BadgeEntity> addBadge(@RequestBody BadgeDTO badge) {
+        return ResponseEntity.ok(badgeService.addBadge(badge));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteBadge(@PathVariable Long id) {
+        badgeService.deleteBadge(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/service_health_monitor_portal/log_analyzer/controllers/ServiceController.java
+++ b/src/main/java/com/service_health_monitor_portal/log_analyzer/controllers/ServiceController.java
@@ -1,6 +1,8 @@
 package com.service_health_monitor_portal.log_analyzer.controllers;
 
 import java.security.Principal;
+import java.util.List;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -9,15 +11,20 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.service_health_monitor_portal.log_analyzer.dto.BadgeIdsDTO;
 import com.service_health_monitor_portal.log_analyzer.dto.ServiceDTO;
+import com.service_health_monitor_portal.log_analyzer.dto.UpdateServiceDTO;
+import com.service_health_monitor_portal.log_analyzer.entity.BadgeEntity;
 import com.service_health_monitor_portal.log_analyzer.entity.ServiceEntity;
 import com.service_health_monitor_portal.log_analyzer.entity.User;
+import com.service_health_monitor_portal.log_analyzer.services.BadgeService;
 import com.service_health_monitor_portal.log_analyzer.services.ServiceService;
 import com.service_health_monitor_portal.log_analyzer.services.UserService;
 
@@ -34,6 +41,9 @@ public class ServiceController {
 
     @Autowired
     private UserService userService;
+
+    @Autowired
+    private BadgeService badgeService;
 
     @PostMapping
     public ResponseEntity<ServiceEntity> addService(
@@ -60,6 +70,59 @@ public class ServiceController {
         } catch (Exception e) {
             System.out.println(e);
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<String> updateService(@PathVariable @NotNull Long id,
+            @RequestBody @Valid UpdateServiceDTO updateService, Principal principal) {
+        try {
+            ServiceEntity service = serviceService.getService(id);
+            if (!service.getUser().getEmail().equals(principal.getName()))
+                return new ResponseEntity<>(HttpStatus.FORBIDDEN);
+            serviceService.updateService(service, updateService);
+            return new ResponseEntity<>("Service Updated Successfully", HttpStatus.OK);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            return new ResponseEntity<>("Service Not Found", HttpStatus.NOT_FOUND);
+        }
+    }
+
+    // Get all badges for a specific service
+    @GetMapping("/{serviceId}/badges")
+    public ResponseEntity<?> getBadges(@PathVariable Long serviceId) {
+        try {
+            Set<BadgeEntity> badges = serviceService.getBadgesForService(serviceId);
+            return ResponseEntity.ok(badges);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body("Error fetching badges for service ID " + serviceId + ": " + e.getMessage());
+        }
+    }
+
+    // Add badges to a service
+    @PostMapping("/{serviceId}/badges")
+    public ResponseEntity<String> addBadges(@PathVariable Long serviceId, @RequestBody BadgeIdsDTO badgeIdsDTO) {
+        List<Long> badgeIds = badgeIdsDTO.getBadgeIds();
+        try {
+            serviceService.addBadgesToService(serviceId, badgeIds);
+            return ResponseEntity.ok("Badges added successfully");
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body("Error adding badges to service ID " + serviceId + ": " + e.getMessage());
+        }
+    }
+
+    // Remove badges from a service
+    @DeleteMapping("/{serviceId}/badges")
+    public ResponseEntity<String> removeBadges(@PathVariable Long serviceId, @RequestBody BadgeIdsDTO badgeIdsDTO) {
+        List<Long> badgeIds = badgeIdsDTO.getBadgeIds();
+        try {
+            serviceService.removeBadgesFromService(serviceId, badgeIds);
+            return ResponseEntity.ok("Badges removed successfully");
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body("Error removing badges from service ID " + serviceId + ": " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/service_health_monitor_portal/log_analyzer/dto/BadgeDTO.java
+++ b/src/main/java/com/service_health_monitor_portal/log_analyzer/dto/BadgeDTO.java
@@ -1,0 +1,14 @@
+package com.service_health_monitor_portal.log_analyzer.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class BadgeDTO {
+
+    @NotNull(message = "Badge's name is required")
+    private String name;
+
+}

--- a/src/main/java/com/service_health_monitor_portal/log_analyzer/dto/UpdateServiceDTO.java
+++ b/src/main/java/com/service_health_monitor_portal/log_analyzer/dto/UpdateServiceDTO.java
@@ -1,26 +1,20 @@
 package com.service_health_monitor_portal.log_analyzer.dto;
 
-import java.sql.Timestamp;
 import java.util.List;
-import java.util.ArrayList;
 
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class ServiceDTO {
-
-    private Long id;
-
-    @NotNull(message = "Service name is required")
+public class UpdateServiceDTO {
     @Pattern(regexp = "^[a-zA-Z0-9_]*$", message = "Service name must contain only alphanumeric characters and underscores")
     private String name;
+
     private String description;
 
-    private List<Long> badgeIds = new ArrayList<>();
+    private List<Long> badgeIds;
 
-    private Timestamp createdAt;
 }

--- a/src/main/java/com/service_health_monitor_portal/log_analyzer/services/BadgeService.java
+++ b/src/main/java/com/service_health_monitor_portal/log_analyzer/services/BadgeService.java
@@ -1,0 +1,38 @@
+package com.service_health_monitor_portal.log_analyzer.services;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.service_health_monitor_portal.log_analyzer.repository.BadgeRepository;
+import com.service_health_monitor_portal.log_analyzer.dto.BadgeDTO;
+import com.service_health_monitor_portal.log_analyzer.entity.BadgeEntity;
+
+@Service
+public class BadgeService {
+    @Autowired
+    private BadgeRepository badgeRepository;
+
+    // Get All Badges
+    public List<BadgeEntity> getAllBadges() {
+        return badgeRepository.findAll();
+    }
+
+    // Get Badge By Id
+    public BadgeEntity getBadgeById(Long id) {
+        return badgeRepository.findById(id).orElse(null);
+    }
+
+    // Add Badge
+    public BadgeEntity addBadge(BadgeDTO badge) {
+        BadgeEntity newBadge = new BadgeEntity();
+        newBadge.setName(badge.getName());
+        return badgeRepository.save(newBadge);
+    }
+
+    // Delete Badge
+    public void deleteBadge(Long id) {
+        badgeRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/service_health_monitor_portal/log_analyzer/services/ServiceService.java
+++ b/src/main/java/com/service_health_monitor_portal/log_analyzer/services/ServiceService.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.lang.reflect.Field;
+import org.springframework.util.ReflectionUtils;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
@@ -18,6 +20,7 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 import com.service_health_monitor_portal.log_analyzer.dto.ServiceDTO;
+import com.service_health_monitor_portal.log_analyzer.dto.UpdateServiceDTO;
 import com.service_health_monitor_portal.log_analyzer.entity.BadgeEntity;
 import com.service_health_monitor_portal.log_analyzer.entity.ServiceEntity;
 import com.service_health_monitor_portal.log_analyzer.entity.User;
@@ -85,6 +88,21 @@ public class ServiceService {
 
     public void deleteService(ServiceEntity service) {
         serviceRepository.delete(service);
+    }
+
+    public void updateService(ServiceEntity service, UpdateServiceDTO updateService) {
+        if (updateService.getName() != null) {
+            service.setName(updateService.getName());
+        }
+        if (updateService.getDescription() != null) {
+            service.setDescription(updateService.getDescription());
+        }
+        if (updateService.getBadgeIds() != null) {
+            List<BadgeEntity> fetchedBadges = badgeRepository.findAllById(updateService.getBadgeIds());
+            Set<BadgeEntity> badges = new HashSet<>(fetchedBadges);
+            service.setBadges(badges);
+        }
+        serviceRepository.save(service);
     }
 
     public Set<BadgeEntity> getBadgesForService(Long serviceId) {


### PR DESCRIPTION
- Introduced `BadgeService` for managing badges, including methods to get, add, and delete badges.
- Updated `BadgeController` to handle badge CRUD operations: fetching all badges, adding a badge, and deleting a badge.
- Modified `ServiceController` to add PATCH method for updating services, including handling updates to the name, description, and associated badges.
- Added `UpdateServiceDTO` for handling service updates.
- Introduced `BadgeDTO` to manage badge data transfer.
- Updated `ServiceDTO` to initialize badgeIds with an empty list by default.
- Added `spring-boot-devtools` to `pom.xml` for development convenience.